### PR TITLE
feat: Add support for on-response phase

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,9 +17,9 @@ endif::[]
 ^|onResponseContent
 
 ^.^| X
-^.^|
 ^.^| X
-^.^|
+^.^| X
+^.^| X
 
 |===
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <description>Description of the Interrupt Policy</description>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>2.5</gravitee-bom.version>
         <gravitee-gateway-api.version>1.34.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>

--- a/src/main/java/io/gravitee/policy/interrupt/configuration/PolicyScope.java
+++ b/src/main/java/io/gravitee/policy/interrupt/configuration/PolicyScope.java
@@ -22,4 +22,7 @@ package io.gravitee.policy.interrupt.configuration;
 public enum PolicyScope {
   REQUEST,
   REQUEST_CONTENT,
+
+  RESPONSE,
+  RESPONSE_CONTENT,
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -4,12 +4,14 @@
   "properties": {
     "scope": {
       "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> (HEAD) phase, <strong>request_content</strong> (includes payload) phase.",
+      "description": "Execute policy on <strong>request</strong> (HEAD) phase, <strong>request_content</strong> (includes payload), <strong>response</strong> (HEAD) phase, <strong>response_content</strong> (includes payload) phase.",
       "type": "string",
       "default": "REQUEST",
       "enum": [
         "REQUEST",
-        "REQUEST_CONTENT"
+        "REQUEST_CONTENT",
+        "RESPONSE",
+        "RESPONSE_CONTENT"
       ],
       "deprecated": true
     },

--- a/src/test/resources/apis/interrupt-onresponse-responsetemplate.json
+++ b/src/test/resources/apis/interrupt-onresponse-responsetemplate.json
@@ -1,0 +1,57 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+      ],
+      "post": [
+        {
+          "name": "Interrupt policy",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-interrupt",
+          "configuration": {
+            "errorKey": "INTERRUPT_ME",
+            "message": "Message in a bottle...",
+            "variables": [
+              {"name":  "my-message", "value":  "An other message in a bottle..."},
+              {"name":  "my-custom-header", "value":  "{#request.headers['my-custom-header']}"}
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "response_templates": {
+    "INTERRUPT_ME": {
+      "*/*": {
+        "status": 400,
+        "body": "{#parameters['my-message']} from {#parameters['my-custom-header']}"
+      }
+    }
+  }
+}

--- a/src/test/resources/apis/interrupt-onresponse.json
+++ b/src/test/resources/apis/interrupt-onresponse.json
@@ -1,0 +1,47 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+      ],
+      "post": [
+        {
+          "name": "Interrupt policy",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-interrupt",
+          "configuration": {
+            "message": "Message in a bottle...",
+            "variables": [
+              {"name":  "my-host-header", "value":  "{#request.headers['host']}"}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/apis/interrupt-onresponsecontent-responsetemplate.json
+++ b/src/test/resources/apis/interrupt-onresponsecontent-responsetemplate.json
@@ -1,0 +1,58 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "POST"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+      ],
+      "post": [
+        {
+          "name": "Interrupt policy",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-interrupt",
+          "configuration": {
+            "scope": "RESPONSE_CONTENT",
+            "errorKey": "INTERRUPT_ME",
+            "message": "Message in a bottle...",
+            "variables": [
+              {"name":  "my-message", "value":  "An other message in a bottle..."},
+              {"name":  "my-custom-header", "value":  "{#request.headers['my-custom-header']}"}
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "response_templates": {
+    "INTERRUPT_ME": {
+      "*/*": {
+        "status": 400,
+        "body": "{#parameters['my-message']} from {#parameters['my-custom-header']}"
+      }
+    }
+  }
+}

--- a/src/test/resources/apis/interrupt-onresponsecontent.json
+++ b/src/test/resources/apis/interrupt-onresponsecontent.json
@@ -1,0 +1,47 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+      ],
+      "post": [
+        {
+          "name": "Interrupt policy",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-interrupt",
+          "configuration": {
+            "scope": "RESPONSE_CONTENT",
+            "errorKey": "INTERRUPT_MdE",
+            "message": "Message in a bottle...",
+            "variables": [
+              {"name":  "my-host-header", "value":  "{#request.headers['host']}"}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.0-on-response-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-interrupt/1.1.0-on-response-SNAPSHOT/gravitee-policy-interrupt-1.1.0-on-response-SNAPSHOT.zip)
  <!-- Version placeholder end -->
