### PR TITLE
adapt dependencies for AM

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,13 +37,13 @@ If you want to override this standard response from the policy, you can define a
 define a Response Template.
 
 
-== Compatibility with APIM
+== Compatibility matrix
 
 |===
-|Plugin version | APIM version
+|Plugin version | APIM version | AM Version
 
-|1.x                  | 3.10.x to 4.5.x
-|2.x                  | 4.6.x to latest
+|1.x                  | 3.10.x to 4.5.x | 3.10.x to 4.10.x
+|2.x                  | 4.6.x to latest | 4.6.x to latest
 |===
 
 == Configuration

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,13 @@
     <description>Break the entire request processing in case of a condition</description>
 
     <properties>
-        <gravitee-apim.version>4.6.0</gravitee-apim.version>
+        <gravitee-apim-gateway-tests-sdk.version>4.6.0</gravitee-apim-gateway-tests-sdk.version>
+
+        <gravitee-bom.version>8.2.0</gravitee-bom.version>
+        <gravitee-gateway-api.version>3.9.1</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-expression-language.version>4.0.0</gravitee-expression-language.version>
+
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
 
         <!-- Property used by the publication job in CI-->
@@ -45,9 +51,9 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee.apim</groupId>
-                <artifactId>gravitee-apim-bom</artifactId>
-                <version>${gravitee-apim.version}</version>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -59,18 +65,21 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
+            <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
+            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.el</groupId>
             <artifactId>gravitee-expression-language</artifactId>
+            <version>${gravitee-expression-language.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -97,7 +106,7 @@
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
-            <version>${gravitee-apim.version}</version>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-adapt-dependencies-for-AM-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-interrupt/2.0.0-adapt-dependencies-for-AM-SNAPSHOT/gravitee-policy-interrupt-2.0.0-adapt-dependencies-for-AM-SNAPSHOT.zip)
  <!-- Version placeholder end -->
