### PR TITLE
feat: enable for A2A proxy

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -9,3 +9,4 @@ category=others
 http_proxy=REQUEST,RESPONSE
 mcp_proxy=REQUEST,RESPONSE
 llm_proxy=REQUEST,RESPONSE
+a2a_proxy=REQUEST,RESPONSE


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12548

**Description**

Enable for A2A proxy.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-12548-enable-for-a2a-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-interrupt/2.1.0-apim-12548-enable-for-a2a-SNAPSHOT/gravitee-policy-interrupt-2.1.0-apim-12548-enable-for-a2a-SNAPSHOT.zip)
  <!-- Version placeholder end -->
